### PR TITLE
Added experimental Route Generators support

### DIFF
--- a/lib/Dispatcher/Compiler.php
+++ b/lib/Dispatcher/Compiler.php
@@ -167,14 +167,18 @@ class Compiler
         }
     }
 
-    protected function getUrl($routeAnnotation, $route)
+    protected function getUrl($routeAnnotation, $route, $args = array())
     {
         $url = new Url($routeAnnotation);
         if (!empty($route)) {
             $url->setRoute($route);
         }
+
         if (isset($args['set'])) {
             $url->setArguments($args['set']);
+        }
+        if (!empty($args[1]) || !empty($args['name'])) {
+            $url->setName(empty($args[1]) ? $args['name'] : $args[1]);
         }
 
         $base = 0;
@@ -228,7 +232,7 @@ class Compiler
             throw new \RuntimeException("@Route must have an argument");
         }
 
-        $url = $this->getUrl($routeAnnotation, $route);
+        $url = $this->getUrl($routeAnnotation, $route, $args);
 
         if ($routeAnnotation->has('Method')) {
             foreach($routeAnnotation->get('Method') as $method) {
@@ -316,6 +320,21 @@ class Compiler
         }
 
         return implode("/", $realPath) . '/' . basename($file1); 
+    }
+
+    public function getNamedUrls()
+    {
+        $urls = array();
+        foreach ($this->urls as $url) {
+            $name = $url->getName();
+            if (empty($name)) continue;
+            if (empty($urls[$name])) {
+                $urls[$name] = array('routes' => array(), 'exception' => '');
+            }
+            $urls[$name]['routes'][]   = $url;
+            $urls[$name]['exception'] .= $url->getRouteDefinition() . " (" . count($url->getVariables()) . " arguments) \n";
+        }
+        return $urls;
     }
 
     public function getNotFoundHandler()

--- a/lib/Dispatcher/Compiler/Component.php
+++ b/lib/Dispatcher/Compiler/Component.php
@@ -119,10 +119,11 @@ class Component
                 } else if ($i != 0) {
                     throw new RuntimeException("If you use multiple variable they should be separated by a constant");
                 }
-                $pos = $i + 1;
-                $i   = strpos($str, '}', $i);
-                $tmp = substr($str, $pos, $i - $pos);
-                $parts[] = array(self::VARIABLE, $tmp);
+                $pos  = $i + 1;
+                $i    = strpos($str, '}', $i);
+                $tmp  = substr($str, $pos, $i - $pos);
+                $name = explode(":", $tmp, 2);
+                $parts[] = array(self::VARIABLE, $tmp, end($name));
                 break;
             default: 
                 $buffer .= $str[$i];

--- a/lib/Dispatcher/Template/Main.tpl.php
+++ b/lib/Dispatcher/Template/Main.tpl.php
@@ -15,6 +15,10 @@ class NotFoundException extends \Exception
 {
 }
 
+class RouteNotFoundException extends \Exception 
+{
+}
+
 interface FilterCache
 {
     public function has($key);
@@ -156,5 +160,35 @@ class Route
         #* render($self->getNotFoundHandler())
 
         throw new NotFoundException;
+    }
+
+    public static function getRoute($name, $args = array())
+    {
+        if (!is_array($args)) {
+            $args = func_get_args();
+            array_shift($args);
+        }
+
+        $count = count($args);
+        switch ($name) {
+        #* 
+        # foreach ($self->getNamedUrls() as $name => $route)
+        case __@name__:
+            #* $routes = $route['routes']
+            #* $exception = $route['exception']
+            #* foreach ($routes as $id => $url)
+            #   $expr = $url->getRouteExpr()
+            #   $filter = $url->getRouteFilter()
+            if (__filter__) {
+                return __expr__;
+            }
+            #* end
+
+            throw new RouteNotFoundException("Invalid arguments for route __name__, possible routes:\n__exception__");
+
+        #* end
+        }
+
+        throw new RouteNotFoundException("There is not route name $name");
     }
 }

--- a/tests/QuickTest.php
+++ b/tests/QuickTest.php
@@ -68,8 +68,9 @@ function filter_2() {
 
 /**
  *  @Route("/foo/bar/{foo}")
- *  @Route("/foo/bar/{bar}")
- *  @Route("/foo/bar/xxx")
+ *  @Route("/foo/bar/{bar}", "foobar_x")
+ *  @Route("/foo/bar/xxx-{bar:xx}", "foobar_xx")
+ *  @Route("/foo/bar/xxx", foobar_xx)
  */
 function TestingMultiple()
 {
@@ -240,5 +241,33 @@ class QuickTest extends \phpunit_framework_testcase
         $route->doRoute($req, array('REQUEST_URI' => '/buffer'));
         $this->assertEquals($req->get('__buffer__'), "Hi there!\n");
         $this->assertTrue($req->get('last_for_all'));
+    }
+
+    /**
+     *  @depends testCompile
+     */
+    public function testGenerator()
+    {
+        $this->assertequals(\quicktest\route::getroute("foobar_x", 'foobar'), '/foo/bar/foobar');
+        $this->assertEquals(\QuickTest\Route::getRoute("foobar_xx", 'foobar'), '/foo/bar/xxx-foobar');
+        $this->assertEquals(\QuickTest\Route::getRoute("foobar_xx"), '/foo/bar/xxx');
+    }
+
+    /**
+     *  @depends testCompile
+     *  @expectedException QuickTest\RouteNotFoundException
+     */
+    public function testGeneratorNotFound()
+    {
+        \QuickTest\Route::getRoute("foobar_xdsdasdada");
+    }
+
+    /**
+     *  @depends testCompile
+     *  @expectedException QuickTest\RouteNotFoundException
+     */
+    public function testGeneratorInvalidArgs()
+    {
+        \quicktest\route::getroute("foobar_x", 'foobar', 'xxx');
     }
 }

--- a/tests/generated/AllTest.php
+++ b/tests/generated/AllTest.php
@@ -12,6 +12,10 @@ class NotFoundException extends \Exception
 {
 }
 
+class RouteNotFoundException extends \Exception 
+{
+}
+
 interface FilterCache
 {
     public function has($key);
@@ -842,5 +846,27 @@ class Route
         
 
         throw new NotFoundException;
+    }
+
+    public static function getRoute($name, $args = array())
+    {
+        if (!is_array($args)) {
+            $args = func_get_args();
+            array_shift($args);
+        }
+
+        $count = count($args);
+        switch ($name) {
+        case 'route_with_id':
+            if ($count == 1 && (!empty($args["__id__"]) || !empty($args[0]))) {
+                return "/" . (!empty($args["__id__"]) ? $args["__id__"] : $args[0]) . "";
+            }
+
+            throw new RouteNotFoundException("Invalid arguments for route route_with_id, possible routes:\n/{__id__} (1 arguments) 
+");
+
+        }
+
+        throw new RouteNotFoundException("There is not route name $name");
     }
 }

--- a/tests/generated/QuickTest.php
+++ b/tests/generated/QuickTest.php
@@ -12,6 +12,10 @@ class NotFoundException extends \Exception
 {
 }
 
+class RouteNotFoundException extends \Exception 
+{
+}
+
 interface FilterCache
 {
     public function has($key);
@@ -465,6 +469,69 @@ class Route
                 }
             }
             // }}} end of /foo/bar/{foo}
+            
+            if (empty($file_92cd6d5b)) {
+               $file_92cd6d5b = 1;
+               require_once __DIR__ . "/../QuickTest.php";
+            }
+            // Routes for /foo/bar/xxx-{bar:xx} {{{
+            if ($parts[0] === 'foo' && $parts[1] === 'bar' && preg_match('/xxx\\-(.+)/', $parts[2], $matches_2) > 0 && \filter_2($req, 'xx', $matches_2[1])) {
+                $req->setIfEmpty('xx', $matches_2[1]);
+                if (empty($file_92cd6d5b)) {
+                   $file_92cd6d5b = 1;
+                   require_once __DIR__ . "/../QuickTest.php";
+                }
+            
+                //run preRoute filters (if any)
+                $allow = true;
+            if (empty($file_92cd6d5b)) {
+               $file_92cd6d5b = 1;
+               require_once __DIR__ . "/../QuickTest.php";
+            }
+                if ($allow) {
+                    $allow &= \__first($req, array (
+            ));
+                }
+            if (empty($file_92cd6d5b)) {
+               $file_92cd6d5b = 1;
+               require_once __DIR__ . "/../QuickTest.php";
+            }
+                if ($allow) {
+                    $allow &= \__last($req, array (
+            ));
+                }
+            
+                // do route
+                if ($allow) {
+                    $req->setIfEmpty('__handler__', '\\TestingMultiple');
+                    $return = \TestingMultiple($req);
+            
+                    // post postRoute (if any)
+                    if (empty($file_92cd6d5b)) {
+                       $file_92cd6d5b = 1;
+                       require_once __DIR__ . "/../QuickTest.php";
+                    }
+                    $return = \__1first($req, array (
+            ), $return);
+                    if (empty($file_92cd6d5b)) {
+                       $file_92cd6d5b = 1;
+                       require_once __DIR__ . "/../QuickTest.php";
+                    }
+                    $return = \__1last($req, array (
+            ), $return);
+                    if (empty($file_92cd6d5b)) {
+                       $file_92cd6d5b = 1;
+                       require_once __DIR__ . "/../QuickTest.php";
+                    }
+                    $return = \__last_for_all($req, array (
+            ), $return);
+            
+            
+            
+                    return $return;
+                }
+            }
+            // }}} end of /foo/bar/xxx-{bar:xx}
             break;
         case 1:
             // Routes for /buffer {{{
@@ -789,5 +856,39 @@ class Route
         // }}} end of @NotFound
 
         throw new NotFoundException;
+    }
+
+    public static function getRoute($name, $args = array())
+    {
+        if (!is_array($args)) {
+            $args = func_get_args();
+            array_shift($args);
+        }
+
+        $count = count($args);
+        switch ($name) {
+        case 'foobar_x':
+            if ($count == 1 && (!empty($args["bar"]) || !empty($args[0]))) {
+                return "/foo/bar/" . (!empty($args["bar"]) ? $args["bar"] : $args[0]) . "";
+            }
+
+            throw new RouteNotFoundException("Invalid arguments for route foobar_x, possible routes:\n/foo/bar/{bar} (1 arguments) 
+");
+
+        case 'foobar_xx':
+            if ($count == 1 && (!empty($args["xx"]) || !empty($args[0]))) {
+                return "/foo/bar/xxx-" . (!empty($args["xx"]) ? $args["xx"] : $args[0]) . "";
+            }
+            if ($count == 0) {
+                return "/foo/bar/xxx";
+            }
+
+            throw new RouteNotFoundException("Invalid arguments for route foobar_xx, possible routes:\n/foo/bar/xxx-{bar:xx} (1 arguments) 
+/foo/bar/xxx (0 arguments) 
+");
+
+        }
+
+        throw new RouteNotFoundException("There is not route name $name");
     }
 }

--- a/tests/input/functions.php
+++ b/tests/input/functions.php
@@ -5,7 +5,7 @@ function __filter__($req, $name, $value) {
     return $value == "id";
 }
 
-/** @Route("/{__id__}") */
+/** @Route("/{__id__}", route_with_id) */
 function empty_level_1($req) {
     return __FUNCTION__;
 }


### PR DESCRIPTION
Url may be named as `@Route("/pattern/{some}", "some_name")`. To generate Urls from the parameters you can call `Route::getRoute("name", "arg1", "arg2")`.
